### PR TITLE
Allow customizing csConfiguration by page language

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -430,7 +430,7 @@ function updateCSConfigurationByPageLang(csConfiguration) {
   if (pageLangChunks.length > 1) {
     langs.push(pageLangChunks[0].toLowerCase() + '-' + pageLangChunks[1].toUpperCase());
   }
-  langs.push(pageLangChunks[0]);
+  langs.push(pageLangChunks[0].toLowerCase());
   for (const lang of langs) {
     if (!csConfigurationByLang.hasOwnProperty(lang)) {
       continue;


### PR DESCRIPTION
This PR allows users to customize `csConfiguration` accordingly to the value of the `lang` attribute of the `<html>` page element (for example: `<html lang="es">`).

How does it work?

First of all, there's this new field to the tag configuration:

![screenshot](https://github.com/iubenda/gtm-cookie-solution/assets/928116/1a09ac16-0086-4a73-b9ad-3ef80032e491)

Users can specify the fields of `csConfiguration` to be customized for every language.

For example: if we have that `<html lang="es-ES">` and that this new fields contains:

```json
{
    "de": {
        "cookiePolicyId": 123
    },
    "es": {
        "cookiePolicyId": 456
    },
    "fr": {
        "cookiePolicyId": 789
    }
}
```

then the final `csConfiguration` will have `lang` set to `"es"` and `cookiePolicyId` set to `456`.

If the page language can't be found in this new json object, nothing changes.

The only problem is that it seems it's not possible to retrieve the `lang` attribute of the `<html>` element from custom google tags (at least, [I still haven't received any answer so far](https://support.google.com/tagmanager/thread/254221592/how-to-detect-page-language-from-custom-tag-templates)).

So, in order to make this improvement work, users have to update the code they insert into web pages.
In particular they have to add this code to every page:

```html
<script>
(window._iub = window._iub || {}).pageLang = window.document && window.document.documentElement ? window.document.documentElement.lang : '';
</script>
```

PS: close #2