### PR TITLE
Remove experimental label from default consent

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,6 +15,8 @@
 homepage: "https://www.iubenda.com"
 documentation: "https://www.iubenda.com/en/help/1177-cookie-solution-getting-started"
 versions:
+  - sha: 734b6a54d0d9f6fa060a682c56885fc12225d508
+    changeNotes: Remove experimental label from default consent
   - sha: 57760e40eebf8b1973d66d0addbff686ad8faa3c
     changeNotes: Enable emitGtmEvents from GTM template
   - sha: 0a35735569cc3489903e99d4323baa7f868f8e40

--- a/template.tpl
+++ b/template.tpl
@@ -462,15 +462,14 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "GROUP",
     "name": "defaultConsentStorageGroup",
-    "displayName": "Apply consent default from storage (experimental)",
+    "displayName": "Apply consent default from storage",
     "groupStyle": "ZIPPY_CLOSED",
     "subParams": [
       {
         "type": "CHECKBOX",
         "name": "enableDefaultConsentFromStorage",
         "checkboxText": "Set the default consent by reading the browser storage",
-        "simpleValueType": true,
-        "help": "This feature is experimental."
+        "simpleValueType": true
       },
       {
         "type": "SELECT",
@@ -1809,6 +1808,10 @@ scenarios: []
 
 
 ___NOTES___
+
+2.4.1 - 2026-05-04
+==================
+* Remove experimental labels from GTM default consent, https://app.asana.com/0/0/1213994105814087/f
 
 2.4.0 - 2025-08-12
 ==================


### PR DESCRIPTION
2.4.1 - 2026-05-04
==================
* Remove experimental labels from GTM default consent